### PR TITLE
Add bus initialization function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 b-imx7
-b-atsam
+b-atsamv

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ all: $(BUILDDIR) $(LIB)
 install: all
 	mkdir -p $(PROJECT_INCLUDE)/grisp
 	install -m 644 $(LIB) $(PROJECT_LIB)
+	install -m 644 include/grisp.h $(PROJECT_INCLUDE)
 	install -m 644 include/grisp/*.h $(PROJECT_INCLUDE)/grisp
 
 $(BUILDDIR):

--- a/include/grisp.h
+++ b/include/grisp.h
@@ -1,11 +1,5 @@
-/*
- * Copyright (c) 2016 embedded brains GmbH.  All rights reserved.
- *
- *  embedded brains GmbH
- *  Dornierstr. 4
- *  82178 Puchheim
- *  Germany
- *  <rtems@embedded-brains.de>
+/* Copyright (c) 2021 Peer Stritzinger GmbH, All rights reserved.
+ * Aumuellerstr. 14, 82216 Maisach, Germany <info@stritzinger.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,47 +23,28 @@
  * SUCH DAMAGE.
  */
 
-#ifndef GRISP_INIT_H
-#define GRISP_INIT_H
-
-#include <rtems.h>
-#include <grisp.h>
+#ifndef GRISP_H
+#define GRISP_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 
-#if defined(GRISP_PLATFORM_GRISP_BASE)
-#define GRISP_SPI_DEVICE "/dev/spibus"
-#define GRISP_I2C0_DEVICE "/dev/i2c-0"
-#define GRISP_I2C1_DEVICE "/dev/i2c-1"
-#elif defined(GRISP_PLATFORM_GRISP2)
-#define GRISP_SPI_FDT_ALIAS "spi0"
-#define GRISP_SPI_DEVICE "/dev/spibus"
-#define GRISP_I2C0_FDT_ALIAS "i2c0"
-#define GRISP_I2C0_DEVICE "/dev/i2c-0"
-#define GRISP_I2C1_FDT_ALIAS "i2c1"
-#define GRISP_I2C1_DEVICE "/dev/i2c-1"
+#include <bsp.h>
+
+#ifdef LIBBSP_ARM_ATSAM_BSP_H
+#define GRISP
+#define GRISP_PLATFORM_GRISP_BASE
+#define GRISP_PLATFORM "grisp_base"
 #endif
-
-typedef void (*grisp_check_and_create_wlandev)(void);
-
-void	grisp_init_buses(void);
-void	grisp_init_libbsd(void);
-void	grisp_init_sd_card(void);
-void	grisp_init_lower_self_prio(void);
-rtems_status_code grisp_init_wait_for_sd(void);
-void	grisp_saf1761_basic_init(void);
-void	grisp_wlan_power_up(void);
-void	grisp_wlan_power_down(void);
-void	grisp_init_wpa_supplicant(const char *conf_file,
-	    rtems_task_priority prio,
-	    grisp_check_and_create_wlandev create_wlan);
-void	grisp_init_dhcpcd(rtems_task_priority prio);
-void	grisp_init_dhcpcd_with_config(rtems_task_priority prio, const char *conf);
+#if defined LIBBSP_ARM_IMX_BSP_H
+#define GRISP
+#define GRISP_PLATFORM_GRISP2
+#define GRISP_PLATFORM "grisp2"
+#endif
 
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
 
-#endif /* GRISP_INIT_H */
+#endif /* GRISP_H */

--- a/src/eeprom.c
+++ b/src/eeprom.c
@@ -29,9 +29,11 @@
  * SUCH DAMAGE.
  */
 
+#include <grisp.h>
+#include <grisp/init.h>
 #include <grisp/eeprom.h>
 #include <bsp.h>
-#if defined(LIBBSP_ARM_ATSAM_BSP_H)
+#if defined(GRISP_PLATFORM_GRISP_BASE)
 #include <bsp/i2c.h>
 #endif
 #include <dev/i2c/eeprom.h>
@@ -42,12 +44,8 @@
 #include <stddef.h>
 #include <inttypes.h>
 
-static const char eeprom_path[] =
-#if defined(LIBBSP_ARM_ATSAM_BSP_H)
-	"/dev/i2c-0.eeprom-0";
-#elif defined(LIBBSP_ARM_IMX_BSP_H)
-	"/dev/i2c-1.eeprom-0";
-#endif
+#define GRISP_EEPROM_DEVICE ".eeprom-0"
+#define EEPROM_PATH GRISP_I2C0_DEVICE GRISP_EEPROM_DEVICE
 #define EEPROM_ADDR 0x57
 #define EEPROM_PAGES 16
 #define EEPROM_PAGE_SIZE 16
@@ -59,28 +57,15 @@ int
 grisp_eeprom_init(void)
 {
 	int rv;
-
-#if defined(LIBBSP_ARM_ATSAM_BSP_H)
 	rv = i2c_dev_register_eeprom(
-	    ATSAM_I2C_0_BUS_PATH,
-	    &eeprom_path[0],
+	    GRISP_I2C0_DEVICE,
+	    GRISP_EEPROM_DEVICE,
 	    EEPROM_ADDR,
 	    1,
 	    EEPROM_PAGE_SIZE,
 	    EEPROM_SIZE,
 	    0
 	);
-#elif defined(LIBBSP_ARM_IMX_BSP_H)
-	rv = i2c_dev_register_eeprom(
-	    "/dev/i2c-1",
-	    &eeprom_path[0],
-	    EEPROM_ADDR,
-	    1,
-	    EEPROM_PAGE_SIZE,
-	    EEPROM_SIZE,
-	    0
-	);
-#endif
 	return rv;
 }
 
@@ -91,7 +76,7 @@ grisp_eeprom_get(struct grisp_eeprom *eeprom)
 	int rv;
 	uint16_t crc = EEPROM_CRC_START_VALUE;
 
-	fd = open(&eeprom_path[0], O_RDONLY);
+	fd = open(GRISP_EEPROM_DEVICE, O_RDONLY);
 	if (fd == -1) {
 		return fd;
 	}
@@ -135,7 +120,7 @@ grisp_eeprom_set(struct grisp_eeprom *eeprom)
 	    offsetof(struct grisp_eeprom, crc16));
 	eeprom->crc16 = crc;
 
-	fd = open(&eeprom_path[0], O_WRONLY);
+	fd = open(GRISP_EEPROM_DEVICE, O_WRONLY);
 	if (fd == -1) {
 		return fd;
 	}


### PR DESCRIPTION
There are a few more places which could use the new `GRISP_PLATFORM_...` macros instead of relying on the BSP macros, but I consider that out of scope for this PR.