### PR TITLE
Integrate DHCP hook for DNS

### DIFF
--- a/include/grisp/init.h
+++ b/include/grisp/init.h
@@ -66,7 +66,6 @@ void	grisp_init_wpa_supplicant(const char *conf_file,
 	    rtems_task_priority prio,
 	    grisp_check_and_create_wlandev create_wlan);
 void	grisp_init_dhcpcd(rtems_task_priority prio);
-void	grisp_init_dhcpcd_with_config(rtems_task_priority prio, const char *conf);
 
 #ifdef __cplusplus
 }

--- a/src/init.c
+++ b/src/init.c
@@ -253,14 +253,24 @@ write_resolv_conf(char * dns_ips) {
 void
 grisp_dhcpcd_hook_handler(rtems_dhcpcd_hook *hook, char *const *env) {
 	(void)hook;
+	char *dns_ips = NULL;
+	bool skip_resolv = false;
 	while (*env != NULL) {
         if (strstr(*env, "new_domain_name_servers") != NULL) {
             char *ip_list_ptr = get_env_value(*env);
-            char *dns_ips = strdup(ip_list_ptr);
-            write_resolv_conf(dns_ips);
-            free(dns_ips);
+            dns_ips = strdup(ip_list_ptr);
+		}
+		if (strstr(*env, "skip_hooks") != NULL &&
+			strstr(*env, "resolv.conf") != NULL) {
+            skip_resolv = true;
 		}
         ++env;
+	}
+	if(dns_ips != NULL) {
+		if (!skip_resolv){
+			write_resolv_conf(dns_ips);
+		}
+        free(dns_ips);
 	}
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -275,25 +275,13 @@ grisp_dhcpcd_hook_handler(rtems_dhcpcd_hook *hook, char *const *env) {
 }
 
 void
-grisp_init_dhcpcd_with_config(rtems_task_priority prio, const char *conf)
+grisp_init_dhcpcd(rtems_task_priority prio)
 {
 	static char *argv_no_conf[] = { "dhcpcd", NULL };
-	static char *argv_conf[] = { "dhcpcd", "-f", NULL, NULL };
-	char *conf_copy = NULL;
 	static rtems_dhcpcd_config config = {};
 
-	if (conf != NULL) {
-		conf_copy = strdup(conf);
-	}
-	if (conf_copy != NULL) {
-		argv_conf[2] = conf_copy;
-		config.argv = argv_conf;
-		config.argc = RTEMS_BSD_ARGC(argv_conf);
-	} else {
-		config.argv = argv_no_conf;
-		config.argc = RTEMS_BSD_ARGC(argv_no_conf);
-	}
-
+	config.argv = argv_no_conf;
+	config.argc = RTEMS_BSD_ARGC(argv_no_conf);
 	config.priority = prio;
 
 	static rtems_dhcpcd_hook dhcpcd_hook = {
@@ -303,12 +291,6 @@ grisp_init_dhcpcd_with_config(rtems_task_priority prio, const char *conf)
 	rtems_dhcpcd_add_hook(&dhcpcd_hook);
 
 	rtems_dhcpcd_start(&config);
-}
-
-void
-grisp_init_dhcpcd(rtems_task_priority prio)
-{
-	grisp_init_dhcpcd_with_config(prio, NULL);
 }
 
 void


### PR DESCRIPTION
This hook will always run. If a dhcpcd file with `option domain_name_servers` is provided as "/etc/dhcpcd.conf", the dhcpcd deamon will provide the variable `new_domain_name_servers`. The hook will use the IP list to overwright the `/etc/resolv.conf` file.
This behaviour can be prevented by specifing `nohook resolv.conf` in the "/etc/dhcpcd.conf"